### PR TITLE
Check base_target_path existence if directory

### DIFF
--- a/bin/apidoc
+++ b/bin/apidoc
@@ -235,6 +235,11 @@ elsif command == "update"
 
         begin
           client.code.get_by_org_key_and_application_key_and_version_and_generator_key(project.org, project.name, project.version, generator.name).files.each do |file|
+            # check if target path ends with the filename - if not, this is a directory target and need to check if dir exists
+            # for example: "play_2_x_routes: api/conf/routes" is a file
+            # while "anorm_2_x_parsers: api/app/generated" should be a directory we check if exists
+            Dir.mkdir(base_target_path) unless base_target_path.include?(file.name) || Dir.exists?(base_target_path)
+
             target_path = File.directory?(base_target_path) ? File.join(base_target_path, file.name) : base_target_path
             existing_source = File.exists?(target_path) ? IO.read(target_path).strip : ""
 


### PR DESCRIPTION
Sometimes a target path for a set of files is a directory that doesn't yet exist. For example, if you declare `anorm_2_x_parsers: api/app/generated` in your `.apidoc` file and the `api/app/generated` directory does not exist, it will assume that the `target_path` to write the file is actually the directory path we wanted.

This ends up happening:
```
 - anorm_2_x_parsers => /Users/paolo/Flow/fulfillment/api/app/generated
 - anorm_2_x_parsers => /Users/paolo/Flow/fulfillment/api/app/generated
 - anorm_2_x_parsers => /Users/paolo/Flow/fulfillment/api/app/generated
 - anorm_2_x_parsers => /Users/paolo/Flow/fulfillment/api/app/generated
 - anorm_2_x_parsers => /Users/paolo/Flow/fulfillment/api/app/generated
 - anorm_2_x_parsers => /Users/paolo/Flow/fulfillment/api/app/generated
```

When we actually want the following, which happens after we create the path `api/app/generated` in the project directory:

```
 - anorm_2_x_parsers => /Users/paolo/Flow/fulfillment/api/app/generated/FlowCommonV0Conversions.scala
 - anorm_2_x_parsers => /Users/paolo/Flow/fulfillment/api/app/generated/FlowCommonV0Parsers.scala
 - anorm_2_x_parsers => /Users/paolo/Flow/fulfillment/api/app/generated/FlowUserV0Conversions.scala
 - anorm_2_x_parsers => /Users/paolo/Flow/fulfillment/api/app/generated/FlowUserV0Parsers.scala
 - anorm_2_x_parsers => /Users/paolo/Flow/fulfillment/api/app/generated/FlowCarrierV0Conversions.scala
 - anorm_2_x_parsers => /Users/paolo/Flow/fulfillment/api/app/generated/FlowCarrierV0Parsers.scala
```

cc @mbryzek 